### PR TITLE
[SDPT 576] Add SDP Instructions for Exactly Once Example

### DIFF
--- a/_posts/Processing Data/2020-03-09-Exactly-Once-Example.md
+++ b/_posts/Processing Data/2020-03-09-Exactly-Once-Example.md
@@ -93,7 +93,7 @@ The **Main Class** for creating the new app is ```io.pravega.example.flink.prime
 Please also make sure to pass the same parameters as discussed in the [original exactly-once post](https://github.com/pravega/pravega-samples/tree/master/flink-connector-examples/doc/exactly-once). The **controller** address in this case is: ```tcp://nautilus-pravega-controller.nautilus-pravega.svc.cluster.local:9090```   
 After finishing the above steps, the **State** for your Flink application should be shown as **Started**.
 
-##### 3. Connect the `ExactlyOnceWriter` application with the Pravega steam on Dell EMC Streaming Data Platform
+##### 3. Connect the `ExactlyOnceWriter` application with the Pravega stream on Dell EMC Streaming Data Platform
 After setting up the Flink app on SDP, configure Streaming Data Platform authentication by getting the ```keycloak.json``` file. Run the following command in your terminal (you may need to change the name for namespace): 
 ```
 kubectl get secret exactlyonce-pravega -n exactlyonce -o jsonpath="{.data.keycloak\.json}" |base64 -d >  ${HOME}/keycloak.json

--- a/_posts/Processing Data/2020-03-09-Pravega-Watermark-Flink-Example.md
+++ b/_posts/Processing Data/2020-03-09-Pravega-Watermark-Flink-Example.md
@@ -113,7 +113,7 @@ The Flink Image for creating the cluster is ```1.9.0```.
 The Main Class for creating the new app is ```io.pravega.example.flink.watermark.EventTimeAverage```. Please also make sure to pass the same parameters as discussed in the [original watermark post](https://github.com/pravega/pravega-samples/tree/master/flink-connector-examples/doc/watermark).  
 After finishing the above steps, the **State** for your Flink application should be shown as **Started**.
 
-##### 3. Connect the `PravegaWatermarkIngestion` application with the Pravega steam on Dell EMC Streaming Data Platform
+##### 3. Connect the `PravegaWatermarkIngestion` application with the Pravega stream on Dell EMC Streaming Data Platform
 After setting up the Flink app on SDP, configure Streaming Data Platform authentication by getting the ```keycloak.json``` file. Run the following command in your terminal (you may need to change the name for namespace): 
 ```
 kubectl get secret watermark-examples-pravega -n watermark-examples -o jsonpath="{.data.keycloak\.json}" |base64 -d >  ${HOME}/keycloak.json


### PR DESCRIPTION
1. Add the instruction for setting up the environment and building the pravega-sample repo.
2. Remove the duplicate instructions and replace them with links to the Github page.
3. Write a general instruction on configuring the sample code on Dell EMC Streaming Data Platform.
4. Fix the typo from the watermark example

Note: There may have a potential bug for Pravega that generates connection failure exception when the parallelism number is larger or equal to 2. However, it did not affect the results of this example. 