### PR TITLE
Added java8 compatibility when building with java11

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -13,6 +13,8 @@ apply plugin: 'jacoco'
 apply plugin: 'java'
 
 version=samplesVersion
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 dependencies {
 	compile "io.pravega:pravega-client:${pravegaVersion}"


### PR DESCRIPTION
Please review - added compatibility flags to use java 8 when compiling with java11 within environment such as IntelliJ